### PR TITLE
use a secure temporary directory

### DIFF
--- a/teiler
+++ b/teiler
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -z "$XDG_RUNTIME_DIR" ]; then
+    TMPDIR=$(mktemp -d)
+    XDG_RUNTIME_DIR=$TMPDIR
+    trap 'rm -rf $TMPDIR; exit' INT QUIT HUP TERM 0
+fi
+
 source /etc/teiler/teiler.conf
 
 if [[ ! -d $HOME/.config/teiler ]]; then
@@ -81,8 +87,8 @@ vid_filemask="${vid_filemask}.${ext}"
 noupload=$save
 
 mainMenu () {
-    if [[ -f /tmp/__teiler_cast_name ]]; then
-        filename="$(cat /tmp/__teiler_cast_name)"
+    if [[ -f $XDG_RUNTIME_DIR/__teiler_cast_name ]]; then
+        filename="$(cat $XDG_RUNTIME_DIR/__teiler_cast_name)"
     fi
     isRecording && STATE_RECORDING="2 Stop Recording Screencast"
     if [[ "$STATE_RECORDING" == "2 Stop Recording Screencast" ]]; then
@@ -158,7 +164,7 @@ test_xrandr () {
 }
 
 screencastMenu () {
-    filename="$(cat /tmp/__teiler_cast_name)"
+    filename="$(cat $XDG_RUNTIME_DIR/__teiler_cast_name)"
     isRecording && STATE_RECORDING="2 Stop Recording Screencast"
     if [[ "$STATE_RECORDING" == "2 Stop Recording Screencast" ]]; then
         HELP="<span color='$help_color'>${upload}: Upload | ${save}: No Upload</span>"
@@ -168,12 +174,12 @@ screencastMenu () {
         if [[ "$menu" == "< Exit" ]]; then
             exit
         fi
-        if [[ $val -eq 10 ]]; then isRecording && stopRecording && sleep 2 && cd "${vid_path}" && teiler_helper --upload video "${filename}" && rm -f /tmp/__teiler_cast_name;
-        elif [[ $val -eq 11 ]]; then isRecording && stopRecording; rm -f /tmp/__teiler_cast_name; notify-send -a "teiler" "teiler" "Screencast saved"; exit
+        if [[ $val -eq 10 ]]; then isRecording && stopRecording && sleep 2 && cd "${vid_path}" && teiler_helper --upload video "${filename}" && rm -f $XDG_RUNTIME_DIR/__teiler_cast_name;
+        elif [[ $val -eq 11 ]]; then isRecording && stopRecording; rm -f $XDG_RUNTIME_DIR/__teiler_cast_name; notify-send -a "teiler" "teiler" "Screencast saved"; exit
         elif [[ $val -eq 1 ]]; then exit
         elif [[ $val -eq 0 ]]; then
             if [[ $always_ul ]]; then isRecording && stopRecording && sleep 2 && cd "${vid_path}" && teiler_helper --upload video "${filename}";
-            elif [[ $always_ul == "0" ]]; then isRecording && stopRecording; rm -f /tmp/__teiler_cast_name; notify-send -a "teiler" "teiler" "Screencast saved"; exit
+            elif [[ $always_ul == "0" ]]; then isRecording && stopRecording; rm -f $XDG_RUNTIME_DIR/__teiler_cast_name; notify-send -a "teiler" "teiler" "Screencast saved"; exit
             fi
         fi
 
@@ -181,7 +187,7 @@ screencastMenu () {
         menu=$(echo -e "< Return to Main Menu\n---\n1 Fullscreen\n2 Area" | roficmd -p "Screencast > ")
         val=$?
         filename="${vid_filemask}"
-        echo "${filename}" > /tmp/__teiler_cast_name
+        echo "${filename}" > $XDG_RUNTIME_DIR/__teiler_cast_name
 
         if [[ $menu == "1 Fullscreen" ]]; then isRecording && stopRecording && sleep 2 || ffmpegCmd fullscreen;
         elif [[ $menu == "2 Area" ]]; then isRecording && stopRecording && sleep 2 || ffmpegCmd area;
@@ -238,16 +244,16 @@ isRecording () { [[ -f "$SCREENCAST_PIDFILE" ]] || return 1; }
 
 stopRecording () {
     local pid
-    if [[ -a /tmp/teiler_res ]]; then
-        res=$(cat /tmp/teiler_res)
+    if [[ -a $XDG_RUNTIME_DIR/teiler_res ]]; then
+        res=$(cat $XDG_RUNTIME_DIR/teiler_res)
     fi
     [[ -f $SCREENCAST_PIDFILE ]] && { pid=$(cat "$SCREENCAST_PIDFILE"); isRecording && kill "$pid"; rm "$SCREENCAST_PIDFILE"; }
     notify-send -a "teiler" -t "1" "teiler" "Stopped recording"
     if [[ -z $rate ]]; then
-        output=$(xininfo -name); xrandr --output "$output" --mode "$res"; rm -f /tmp/teiler_res; return 0
+        output=$(xininfo -name); xrandr --output "$output" --mode "$res"; rm -f $XDG_RUNTIME_DIR/teiler_res; return 0
     else
      if [[ -n $res ]]; then
-        output=$(xininfo -name); xrandr --output "$output" --mode "$res" --rate "${rate}"; rm -f /tmp/teiler_res; return 0
+        output=$(xininfo -name); xrandr --output "$output" --mode "$res" --rate "${rate}"; rm -f $XDG_RUNTIME_DIR/teiler_res; return 0
       fi
     fi
 }
@@ -272,13 +278,13 @@ ffmpegCmd () {
 
     source "$HOME/.config/teiler/profiles/${profile}"
 
-    echo "${filename}" > /tmp/__teiler_cast_name
+    echo "${filename}" > $XDG_RUNTIME_DIR/__teiler_cast_name
     if [[ $1 == "fullscreen" ]]; then
         isRecording && { notify "$time" 'Screencast already in progress'; echo "Already recording Screen"; exit 1; }
         ffmpeg_display=$(echo $DISPLAY)
         ffmpeg_offset="$(xininfo -mon-x),$(xininfo -mon-y)"
         if [[ -n $res_now ]]; then
-            echo "$res_now" > /tmp/teiler_res
+            echo "$res_now" > $XDG_RUNTIME_DIR/teiler_res
         fi
         if [[ $res_now == $res ]]; then echo " "
         else output=$(xininfo -name); xrandr --output "$output" --mode "$res"; sleep 5; fi
@@ -319,22 +325,22 @@ maimCmd () {
 }
 
 askPrompt () {
-    filename="$(cat /tmp/__teiler_cast_name)"
+    filename="$(cat $XDG_RUNTIME_DIR/__teiler_cast_name)"
     isRecording && STATE_RECORDING="Recording"
     if [[ -z "$STATE_RECORDING" ]]; then
         filename="${vid_filemask}"
-        echo "${filename}" > /tmp/__teiler_cast_name
+        echo "${filename}" > $XDG_RUNTIME_DIR/__teiler_cast_name
         menu=$(echo -e "< Exit\n---\n1 Fullscreen\n2 Area" | roficmd -p "> ")
         if [[ $menu == "1 Fullscreen" ]]; then isRecording && stopRecording && sleep 2 || ffmpegCmd fullscreen;
         elif [[ $menu == "2 Area" ]]; then isRecording && stopRecording && sleep 2 || ffmpegCmd area;
         elif [[ $menu == "" ]]; then exit
         fi
     else
-        filename="$(cat /tmp/__teiler_cast_name)"
+        filename="$(cat $XDG_RUNTIME_DIR/__teiler_cast_name)"
         isRecording && stopRecording && sleep 2
         ask=$(echo -e "1 Yes\n2 No" | roficmd -p "Upload? > ")
-        if [[ $ask == "1 Yes" ]]; then cd "${vid_path}" && teiler_helper --upload video "${filename}" && rm -f /tmp/__teiler_cast_name;
-        elif [[ $ask == "2 No" ]]; then rm -f /tmp/__teiler_cast_name;
+        if [[ $ask == "1 Yes" ]]; then cd "${vid_path}" && teiler_helper --upload video "${filename}" && rm -f $XDG_RUNTIME_DIR/__teiler_cast_name;
+        elif [[ $ask == "2 No" ]]; then rm -f $XDG_RUNTIME_DIR/__teiler_cast_name;
         fi
     fi
 }


### PR DESCRIPTION
the previous code was using a fixed-name for a temporary file that was
used to store the name of the file to be uploaded. an attacker could
abuse this to make teiler upload arbitrary files the user has access
to to a paste site. since most paste sites supported are fairly
public, this could lead to elevated privileges, information disclosure
or even remote code execution (think of .ssh/id_rsa).