### PR TITLE
Fix video upload for S3

### DIFF
--- a/teiler_helper
+++ b/teiler_helper
@@ -14,7 +14,7 @@ fi
 # define uploaders
 # images
 if [[ $img_ul == "fb" ]]; then
-    imageUpload () { 
+    imageUpload () {
         if [[ $(echo "$files" | wc -w) -gt 1 ]]; then
             cd "${img_path}"; fb -m ${@}; x_clip; notify-send -a "teiler" "Image Uploaded" "$(xclip -o)"
         else
@@ -39,7 +39,7 @@ if [[ $vid_ul == "fb" ]]; then
 elif [[ $vid_ul == "scp" ]]; then
     videoUpload () { scpUpload "Video" "${vid_path}" "$1" "${scp_host}" "${scp_path_vid}" "${http_vid}"; }
 elif [[ $vid_ul == "s3" ]]; then
-    videoUpload () { cd "${vid_path}"; s3cmd --no-progress put "{$1}" "s3://${s3_bucket}/${s3_path_vid}/"; notify-send -a "teiler" "Video Uploaded" "${s3_http_vid}/${1}"; echo -n "${s3_http_vid}/${1}" | xclip; x_clip; }
+    videoUpload () { cd "${vid_path}"; s3cmd --no-progress put "${1}" "s3://${s3_bucket}/${s3_path_vid}/"; notify-send -a "teiler" "Video Uploaded" "${s3_http_vid}/${1}"; echo -n "${s3_http_vid}/${1}" | xclip; x_clip; }
 else
     videoUpload () { echo "No video uploader set. Check example config"; }
 fi


### PR DESCRIPTION
There is syntax error in S3 helper for videos - `{$1}` is used and s3cmd failing with error:

```
+ s3cmd --no-progress put '{vid-2016-12-23-210730.mp}' s3://up.ssbb.me/videos/
ERROR: Parameter problem: Nothing to upload.
```