### PR TITLE
Add upload options "none" and "clipboard"

### DIFF
--- a/config.example
+++ b/config.example
@@ -21,9 +21,9 @@ player=mpv
 always_ul=1
 
 # Uploading options
-# Possible Choices for img_ul: fb, scp, s3, imgur
-# Possible Choices for vid_ul: fb, scp, s3
-# Possible Choices for paste_ul: fb, scp, ix
+# Possible Choices for img_ul: fb, scp, s3, imgur, clipboard, none
+# Possible Choices for vid_ul: fb, scp, s3, none
+# Possible Choices for paste_ul: fb, scp, ix, none
 img_ul=imgur
 vid_ul=fb
 paste_ul=ix

--- a/teiler_helper
+++ b/teiler_helper
@@ -28,6 +28,10 @@ elif [[ $img_ul == "imgur" ]]; then
     imageUpload () { cd "${img_path}"; for x in $files; do imgurbash2 "${x}"; x_clip; notify-send -a "teiler" "Image Uploaded" "$(xclip -o)"; done; }
 elif [[ $img_ul == "s3" ]]; then
     imageUpload () { cd "${img_path}"; s3cmd --no-progress put "${1}" "s3://${s3_bucket}/${s3_path_img}/"; notify-send -a "teiler" "Image Uploaded" "${s3_http_img}/${1}"; echo -n "${s3_http_img}/${1}" | xclip; x_clip; }
+elif [[ $img_ul == "clipboard" ]]; then
+    imageUpload () { xclip -selection clipboard -t image/png ${1}; notify-send -a "teiler" "Image Saved and copied to clipboard" "${1}"; }
+elif [[ $img_ul == "none" ]]; then
+    imageUpload () { echo "${1}" | xclip; x_clip; notify-send -a "teiler" "Image Saved" "$(xclip -o)"; }
 else
     imageUpload () { echo "No image uploader set. check example config"; }
 fi
@@ -40,6 +44,8 @@ elif [[ $vid_ul == "scp" ]]; then
     videoUpload () { scpUpload "Video" "${vid_path}" "$1" "${scp_host}" "${scp_path_vid}" "${http_vid}"; }
 elif [[ $vid_ul == "s3" ]]; then
     videoUpload () { cd "${vid_path}"; s3cmd --no-progress put "${1}" "s3://${s3_bucket}/${s3_path_vid}/"; notify-send -a "teiler" "Video Uploaded" "${s3_http_vid}/${1}"; echo -n "${s3_http_vid}/${1}" | xclip; x_clip; }
+elif [[ $vid_ul == "none" ]]; then
+    videoUpload () { echo "${1}" | xclip; x_clip; notify-send -a "teiler" "Video Saved" "$(xclip -o)"; }
 else
     videoUpload () { echo "No video uploader set. Check example config"; }
 fi
@@ -51,6 +57,8 @@ elif [[ $paste_ul == "scp" ]]; then
     clipUpload () { scpUpload "Paste" "${paste_path}" "$1" "${scp_host}" "${scp_path_paste}" "${http_paste}"; }
 elif [[ $paste_ul == "ix" ]]; then
     clipUpload () { xclip -o 2>&1 | curl -F 'f:1=<-' ix.io | tr -d "\n" | xclip; x_clip; notify-send -a "teiler" "Paste Uploaded" "$(xclip -o)"; }
+elif [[ $paste_ul == "none" ]]; then
+    clipUpload () { echo "${1}" | xclip; x_clip; notify-send -a "teiler" "Paste Saved" "$(xclip -o)"; }
 else
     clipUpload () { echo "No text uploader set. Check example config"; }
 fi


### PR DESCRIPTION
None allows silencing "No uploader set" message when you don't want
to use the upload functionality.

Clipboard just copies the image so it can be pasted elsewhere.