### PR TITLE
Fix pluralization typo in help text.

### DIFF
--- a/teiler
+++ b/teiler
@@ -404,7 +404,7 @@ teiler - a rofi-driven screen{shot,cast} utility
 (C) Rasmus Steinke <rasi@xssn.at>
 --screenshot                               open screenshots menu
 --screencast                               open screencasts menu
---history {images,video}                   open history menus
+--history {images,videos}                  open history menus
 --paste                                    upload text from clipboard
 --togglecast                               start/stop screencast
 --quick image {area,fullscreen,all,active} quickly create screenshot and upload


### PR DESCRIPTION
This PR fixes a small error in hel (apparently `teiler --history videos` is correct).